### PR TITLE
Make `mrb_load_exec()` return `nil` if there is a syntax error

### DIFF
--- a/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
+++ b/mrbgems/mruby-bin-debugger/tools/mrdb/mrdb.c
@@ -708,7 +708,7 @@ main(int argc, char **argv)
     v = mrb_load_file_cxt(mrb, args.rfp, cc);
     mrbc_context_free(mrb, cc);
   }
-  if (mrdb->dbg->xm == DBG_QUIT && !mrb_undef_p(v) && mrb->exc) {
+  if (mrdb->dbg->xm == DBG_QUIT && mrb->exc) {
     const char *classname = mrb_obj_classname(mrb, mrb_obj_value(mrb->exc));
     if (!strcmp(classname, "DebuggerExit")) {
       cleanup(mrb, &args);
@@ -732,14 +732,12 @@ main(int argc, char **argv)
   }
   puts("mruby application exited.");
   mrdb->dbg->xphase = DBG_PHASE_AFTER_RUN;
-  if (!mrb_undef_p(v)) {
-    if (mrb->exc) {
-      mrb_print_error(mrb);
-    }
-    else {
-      printf(" => ");
-      mrb_p(mrb, v);
-    }
+  if (mrb->exc) {
+    mrb_print_error(mrb);
+  }
+  else {
+    printf(" => ");
+    mrb_p(mrb, v);
   }
 
   mrdb->dbg->prvfile = "-";

--- a/mrbgems/mruby-compiler/core/parse.y
+++ b/mrbgems/mruby-compiler/core/parse.y
@@ -6816,7 +6816,13 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c)
   mrb_int keep = 0;
 
   if (!p) {
-    return mrb_undef_value();
+    if (mrb->gc.out_of_memory) {
+      mrb->exc = mrb->nomem_err;
+    }
+    else {
+      mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_RUNTIME_ERROR, "wrong NULL as parser_state"));
+    }
+    return mrb_nil_value();
   }
   if (!p->tree || p->nerr) {
     if (c) c->parser_nerr = p->nerr;
@@ -6829,14 +6835,14 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c)
       strncat(buf, p->error_buffer[0].message, sizeof(buf) - strlen(buf) - 1);
       mrb->exc = mrb_obj_ptr(mrb_exc_new(mrb, E_SYNTAX_ERROR, buf, strlen(buf)));
       mrb_parser_free(p);
-      return mrb_undef_value();
+      return mrb_nil_value();
     }
     else {
       if (mrb->exc == NULL) {
         mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_SYNTAX_ERROR, "syntax error"));
       }
       mrb_parser_free(p);
-      return mrb_undef_value();
+      return mrb_nil_value();
     }
   }
   proc = mrb_generate_code(mrb, p);
@@ -6845,7 +6851,7 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c)
     if (mrb->exc == NULL) {
       mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_SCRIPT_ERROR, "codegen error"));
     }
-    return mrb_undef_value();
+    return mrb_nil_value();
   }
   if (c) {
     if (c->dump_result) mrb_codedump_all(mrb, proc);

--- a/mrbgems/mruby-compiler/core/y.tab.c
+++ b/mrbgems/mruby-compiler/core/y.tab.c
@@ -13008,7 +13008,13 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c)
   mrb_int keep = 0;
 
   if (!p) {
-    return mrb_undef_value();
+    if (mrb->gc.out_of_memory) {
+      mrb->exc = mrb->nomem_err;
+    }
+    else {
+      mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_RUNTIME_ERROR, "wrong NULL as parser_state"));
+    }
+    return mrb_nil_value();
   }
   if (!p->tree || p->nerr) {
     if (c) c->parser_nerr = p->nerr;
@@ -13021,14 +13027,14 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c)
       strncat(buf, p->error_buffer[0].message, sizeof(buf) - strlen(buf) - 1);
       mrb->exc = mrb_obj_ptr(mrb_exc_new(mrb, E_SYNTAX_ERROR, buf, strlen(buf)));
       mrb_parser_free(p);
-      return mrb_undef_value();
+      return mrb_nil_value();
     }
     else {
       if (mrb->exc == NULL) {
         mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_SYNTAX_ERROR, "syntax error"));
       }
       mrb_parser_free(p);
-      return mrb_undef_value();
+      return mrb_nil_value();
     }
   }
   proc = mrb_generate_code(mrb, p);
@@ -13037,7 +13043,7 @@ mrb_load_exec(mrb_state *mrb, struct mrb_parser_state *p, mrbc_context *c)
     if (mrb->exc == NULL) {
       mrb->exc = mrb_obj_ptr(mrb_exc_new_lit(mrb, E_SCRIPT_ERROR, "codegen error"));
     }
-    return mrb_undef_value();
+    return mrb_nil_value();
   }
   if (c) {
     if (c->dump_result) mrb_codedump_all(mrb, proc);


### PR DESCRIPTION
Previously it returned `undef`.
So for example, if there was a syntax error, the following code would cause `SIGSEGV`.

```c
const char *code = "syntax ? error ?";
mrb_p(mrb, mrb_load_string(mrb, code));
```

This affects the behavior of the `MRB_API` function below:
- `mrb_load_file()`
- `mrb_load_file_cxt()`
- `mrb_load_detect_file_cxt()`
- `mrb_load_string()`
- `mrb_load_nstring()`
- `mrb_load_string_cxt()`
- `mrb_load_nstring_cxt()`

I mentioned earlier why I want to change from `undef` to `nil`, but here's why I decided to change it:
- Returns `nil` if an error occurred when returning from `mrb_top_run()`.
- The specific error can be found by confirming that `mrb->exc` is non-`NULL`.
- Even if `mrbc_context::no_exec` is true, it is sufficient to check if it is either `proc` or `nil`.

However, this change can cause compatibility issues if it has already used `mrb_undef_p()` to distinguish between syntax errors. This is the reason for making changes to the `mrdb.c` file (although the behavior does not change with or without changes).