### PR TITLE
Prepare stub functions for libmruby_core in core

### DIFF
--- a/lib/mruby/build.rb
+++ b/lib/mruby/build.rb
@@ -76,7 +76,8 @@ module MRuby
     include Rake::DSL
     include LoadGems
     attr_accessor :name, :bins, :exts, :file_separator, :build_dir, :gem_clone_dir, :defines
-    attr_reader :products, :libmruby_core_objs, :libmruby_objs, :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
+    attr_reader :products, :libmruby_core_only_objs, :libmruby_core_objs, :libmruby_objs
+    attr_reader :gems, :toolchains, :presym, :mrbc_build, :gem_dir_to_repo_url
 
     alias libmruby libmruby_objs
 
@@ -117,6 +118,7 @@ module MRuby
         @products = []
         @bins = []
         @gems = MRuby::Gem::List.new
+        @libmruby_core_only_objs = []
         @libmruby_core_objs = []
         @libmruby_objs = [@libmruby_core_objs]
         @enable_libmruby = true

--- a/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
+++ b/mrbgems/mruby-bin-mrbc/tools/mrbc/mrbc.c
@@ -357,15 +357,3 @@ main(int argc, char **argv)
   }
   return EXIT_SUCCESS;
 }
-
-void
-mrb_init_mrblib(mrb_state *mrb)
-{
-}
-
-#ifndef MRB_NO_GEMS
-void
-mrb_init_mrbgems(mrb_state *mrb)
-{
-}
-#endif

--- a/src/coreonly/stub.c
+++ b/src/coreonly/stub.c
@@ -1,9 +1,26 @@
-#include <mruby.h>
+/*
+** stub.c - stub functions for libmruby_core
+**
+** See Copyright Notice in mruby.h
+*/
 
 /*
   functions defined in mrbgems referenced from the core should be listed here
   to avoid link errors, since mrbc does not link any mrbgem ignoring configuration.
 */
+
+#include <mruby.h>
+
+void
+mrb_init_mrblib(mrb_state *mrb)
+{
+}
+
+#ifndef MRB_NO_GEMS
+void mrb_init_mrbgems(mrb_state *mrb)
+{
+}
+#endif
 
 #ifdef MRB_USE_COMPLEX
 mrb_value mrb_complex_new(mrb_state *mrb, mrb_float x, mrb_float y)

--- a/tasks/core.rake
+++ b/tasks/core.rake
@@ -9,4 +9,9 @@ MRuby.each_target do
     end
   end
   self.libmruby_core_objs << objs
+
+  Dir.glob("#{MRUBY_ROOT}/src/coreonly/*.c").each do |src|
+    obj = objfile(src.pathmap("#{build_dir}/src/coreonly/%n"))
+    self.libmruby_core_only_objs << obj
+  end
 end

--- a/tasks/libmruby.rake
+++ b/tasks/libmruby.rake
@@ -1,5 +1,5 @@
 MRuby.each_target do
-  file libmruby_core_static => libmruby_core_objs.flatten do |t|
+  file libmruby_core_static => [libmruby_core_objs, libmruby_core_only_objs].flatten do |t|
     archiver.run t.name, t.prerequisites
   end
 


### PR DESCRIPTION
The `MRuby::Build#libmruby_core_only_objs` accessor has been added for this purpose. It probably does not make sense for users to use this accessor.

And, the `mruby-bin-mrbc/src/stub.c` file has been moved to `mruby/src/coreonly/stub.c`. The object files generated from this file are passed to the newly created accessor.